### PR TITLE
support burning via anyswap bridge

### DIFF
--- a/contracts/Interfaces/IAnySwapERC20.sol
+++ b/contracts/Interfaces/IAnySwapERC20.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.6.11;
+
+import "../Dependencies/IERC20.sol";
+
+interface IAnySwapERC20 is IERC20 {
+
+    function Swapout(uint256 amount, address bindaddr) external returns (bool);
+
+}


### PR DESCRIPTION
Within the pool2 staker, support burning on child chains by performing a Swapout to the dead address.